### PR TITLE
SIMD Unary MathOps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,11 +27,12 @@ jobs:
             mingw-w64-ucrt-x86_64-pkgconf
             mingw-w64-ucrt-x86_64-rtaudio
             mingw-w64-ucrt-x86_64-readline
+            mingw-w64-ucrt-x86_64-ca-certificates
       - name: CI-Build
         run: |
-          echo 'Running in MSYS2!'
-          meson setup build
-          meson compile -C build
+          meson setup --buildtype release build
+          meson test --verbose -C build
+          meson compile sapf_x86_64_v3 -C build
       - name: Save Build Log Artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
@@ -57,10 +58,18 @@ jobs:
       run: .github/scripts/install-macos-deps.sh
 
     - name: Setup
-      run: meson setup build
+      run: meson setup --buildtype release build
 
-    - name: Compile
-      run: meson compile -C build
+    - name: Test
+      run: meson test --verbose -C build
+
+    - name: Compile M1
+      if: runner.os == 'macOS'
+      run: meson compile sapf_arm_m1 -C build
+
+    - name: Compile Linux x86
+      if: runner.os != 'macOS'
+      run: meson compile sapf_x86_64_v3 -C build
 
     - name: Save Build Log Artifact
       if: ${{ always() }}

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ xcshareddata/
 *.moved-aside
 *.xcuserstate
 .vscode/
+.idea/
+subprojects/*/

--- a/README.md
+++ b/README.md
@@ -10,11 +10,24 @@ a Nix flake is included. simply run:
 
 ```shell
 nix develop
-meson setup build
+meson setup --buildtype release build
 meson compile -C build
 ```
 
-and you should get a binary at `./build/sapf`.
+and you should get a binary at `./build/sapf`. This will be optimized for your
+native architecture and has the maximum level of optimization. This is recommended for
+normal usage. 
+
+To build an
+unoptimized binary, simply omit the `--buildtype release` param (which will default to
+`--buildtype debug`). If you've already ran `setup` and want to change the buildtype to `debug`, you can run
+```shell
+meson configure --buildtype debug build
+meson compile -C build
+```
+Note you can view the current buildtype setting via `meson configure build`.
+
+You can specify different targets defined in the meson.build file such as `meson compile sapf_x86_64_v3 -C build`.
 
 if not using Nix, you will need to install dependencies manually instead of the `nix develop`. the mandatory dependencies for a portable build are currently:
 
@@ -27,6 +40,28 @@ for installing dependencies, you can refer to the CI scripts in this repo:
 
 - [install-debian-deps.sh](.github/scripts/install-debian-deps.sh) (Debian, Ubuntu, Mint, etc.)
 - [install-macos-deps.sh](.github/scripts/install-macos-deps.sh) (macOS with Homebrew)
+
+## running tests
+Tests are written using doctest (which is obtained via a wrap) and located in the `tests` folder.
+See [the doctest documentation](https://github.com/doctest/doctest/tree/master?tab=readme-ov-file#documentation) for more details.
+
+You can use meson test to run the tests.
+
+This will respect the `--buildtype` setting. For optimal debugging experience,
+you should use the `debug` buildtype. You can check the current buildtype with
+`meson configure build`. To change it, you can run `meson configure --buildtype debug build`.
+
+The below will run the tests
+```shell
+meson test --verbose -C build
+```
+Without `--verbose` you won't get the doctest test report (not to be confused with meson's
+own, less useful test report) printed to stdout and instead would have to view the test
+log file.
+
+Note there is currently a feature request for doctest for better integration 
+with meson but it is not yet implemented ATTOW: https://github.com/doctest/doctest/issues/531
+This seems to be why the default meson test report isn't that useful.
 
 ## Windows Usage Caveats
 
@@ -48,24 +83,28 @@ if the package exists for your architecture.
 "root directory" is for your msys2 / mingw64 shells. For this guide we will assume the default of `C:\msys64`
 2. If you haven't yet, clone or copy this repo somewhere inside the msys2 install. For example within the msys2 shell you could install git via
 `pacman -S git` and then git clone this repo into your "home" folder.
-3. Open a msys2 (ucrt) shell and install some needed development dependencies
+3. Open a msys2 (ucrt) shell and install some needed development dependencies.
+    (Note the ca-certificates are required in order to download the gtest wrap, and in general you'll
+    have a bad time doing anything on msys2 without these certs.)
    ```shell
    # press ENTER when prompted to choose "all"
-   pacman -S --needed base-devel mingw-w64-ucrt-x86_64-toolchain
+   pacman -S --needed base-devel \
+    mingw-w64-ucrt-x86_64-toolchain
    pacman -S \
     mingw-w64-ucrt-x86_64-meson \
     mingw-w64-ucrt-x86_64-fftw \
     mingw-w64-ucrt-x86_64-libsndfile \
     mingw-w64-ucrt-x86_64-pkgconf \
     mingw-w64-ucrt-x86_64-rtaudio \
-    mingw-w64-ucrt-x86_64-readline
+    mingw-w64-ucrt-x86_64-readline \
+    mingw-w64-ucrt-x86_64-ca-certificates
    ```
 4. Close and reopen the shell to ensure it loads everything you just installed. 
 5. Now we can try to build in the msys2 (ucrt) shell.
 Navigate to the root directory of this repo.
 6.  ```shell
-    # remove --buildtype debug to build without debug symbols
-    meson setup --buildtype debug build 
+    # remove --buildtype release to build an unoptimized exe with debug symbols
+    meson setup --buildtype release build 
     meson compile -C build
     ```
 7. You should see `sapf.exe` is created under the `${workspaceFolder}/build` directory.
@@ -80,6 +119,3 @@ When setting up your IDE, make sure it's using the ucrt64 libraries (C:\msys64\u
 and binaries (C:\msys64\ucrt64\bin) for compilation / linking and NOT your native windows libraries / binaries.
 
 See README_VSCODE.md for vscode-specific setup.
-Since it's not exactly straightforward to get everything working nicely in VSCode under Windows, here's 
-some guidance.
-

--- a/README_VSCODE.md
+++ b/README_VSCODE.md
@@ -13,7 +13,8 @@ a version string. You can also confirm with `where gcc` that it's using the bina
 6. Before opening the folder in vscode, create a `.vscode` subdolder and populate it with some files. See the below "Config files" section for some example config files. Tweak the paths to match your own system.
 7. Open a cpp file to make sure the extensions activate.
 8. You should now have intellisense working (you should be able to "Go to definition" and "find references, etc...").
-9. You can now build using the Meson build task instead of msys2 shell if you prefer.
+9. You can now build using the Meson build task instead of msys2 shell if you prefer. For best
+debugging experience you probably want to build the `sapf_unoptimized_testable` target which disables optimizations.
 10. You can debug via selecting the "Attach (sapf)" configuration (bottom left), manually
 running sapf.exe, and then presing F5 and attaching to the sapf.exe process. (Currently haven't figured out
 how to get the "launch" version working - it runs but the text is garbled - likely an encoding issue).
@@ -105,6 +106,36 @@ Example `.vscode/launch.json`
                     "ignoreFailures": true
                 }
             ]
+        },
+        {
+            "name": "(gdb) Debug Test",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/build/test_unoptimized.exe",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceRoot}/build",
+            "environment": [
+                { "name": "MSYSTEM", "value": "UCRT64" },
+                { "name": "MSYS2_PATH_TYPE", "value": "inherit" },
+                { "name": "PATH", "value": "C:\\msys64\\ucrt64\\bin;${env:PATH}" }
+            ],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "miDebuggerPath": "C:\\msys64\\ucrt64\\bin\\gdb.exe",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ],
+            "preLaunchTask": "Meson: Build test_unoptimized:executable"
         }
     ]
 }

--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,6 @@ sources = [
   'src/elapsedTime.cpp',
   'src/ErrorCodes.cpp',
   'src/FilterUGens.cpp',
-  'src/main.cpp',
   'src/MathFuns.cpp',
   'src/MathOps.cpp',
   'src/Midi.cpp',
@@ -61,6 +60,7 @@ if get_option('accelerate')
   add_project_arguments('-DSAPF_ACCELERATE', language: 'cpp')
 else
   deps += dependency('fftw3', required: true, version: '>=3')
+  deps += dependency('eigen3', required: true)
 endif
 
 if get_option('apple_lock')
@@ -112,11 +112,95 @@ if get_option('manta')
   add_project_arguments('-DSAPF_MANTA', language: 'cpp')
 endif
 
+# main should only be in release build because otherwise it conflicts with the main
+# method added by doctest in test builds
+release_sources = sources + 'src/main.cpp'
+
+# build targeting the native system this was built on. If buildtype is debug,
+# no target architecture will be specified, to ensure the best debugging experience.
 executable(
   'sapf',
-  sources,
+  release_sources,
   include_directories: [include_directories('include')],
   dependencies: deps,
-  cpp_args : cpp_args,
+  cpp_args : cpp_args + (get_option('buildtype').startswith('debug') ? [] : ['-march=native']),
   link_args : link_args
 )
+
+# The below builds target specific architectures. Because this program uses
+# SIMD, the best performance is achieved when a user uses the most recent architecture supported
+# by their CPU. However, users will get the best results (even better performance) if they build the
+# library themselves (target `sapf` above with `--buildtype release`)
+
+# should have maximum compatibility with ancient x86_64 cpus
+executable(
+  'sapf_x86_64',
+  release_sources,
+  include_directories: [include_directories('include')],
+  dependencies: deps,
+  cpp_args : cpp_args + ['-march==x86-64'],
+  link_args : link_args,
+  build_by_default: false
+)
+
+# for somewhat older x86 CPUs (2008ish)
+executable(
+  'sapf_x86_64_v2',
+  release_sources,
+  include_directories: [include_directories('include')],
+  dependencies: deps,
+  cpp_args : cpp_args + ['-march=x86-64-v2'],
+  link_args : link_args,
+  build_by_default: false
+)
+
+# for more cutting edge x86 cpus
+executable(
+  'sapf_x86_64_v3',
+  release_sources,
+  include_directories: [include_directories('include')],
+  dependencies: deps,
+  cpp_args : cpp_args + ['-march=x86-64-v3'],
+  link_args : link_args,
+  build_by_default: false
+)
+
+# support M1 chip and newer
+executable(
+  'sapf_arm_m1',
+  release_sources,
+  include_directories: [include_directories('include')],
+  dependencies: deps,
+  cpp_args : cpp_args + ['-march=armv8.4-a', '-mcpu=apple-m1'],
+  link_args : link_args,
+  build_by_default: false
+)
+
+# support M3 chip
+executable(
+  'sapf_arm_m3',
+  release_sources,
+  include_directories: [include_directories('include')],
+  dependencies: deps,
+  cpp_args : cpp_args + ['-march=armv8.5-a', '-mcpu=apple-m3'],
+  link_args : link_args,
+  build_by_default: false
+)
+
+# tests
+test_deps = deps + dependency('doctest', required: true)
+test_sources = sources + 'test/test_MathOps.cpp'
+
+# Just like the main executable, this respects the buildtype param. The target architecture is
+# omitted if it's a debug build, ensuring the best debugging experience
+test_sapf = executable(
+  'test_sapf',
+  test_sources,
+  include_directories: [include_directories('include')],
+  dependencies: test_deps,
+  cpp_args :  cpp_args + (get_option('buildtype').startswith('debug') ? [] : ['-march=native']),
+  link_args : link_args,
+  build_by_default: false
+)
+
+test('all', test_sapf)

--- a/src/MathOps.cpp
+++ b/src/MathOps.cpp
@@ -436,24 +436,45 @@ static void DoIReduce(Thread& th, BinaryOp* op)
 	UnaryOp* gUnaryOpPtr_##NAME = &gUnaryOp_##NAME; \
 	UNARY_OP_PRIM(NAME)
 #else
-#define DEFINE_UNOP_FLOATVV(NAME, CODE, VVNAME) \
-	struct UnaryOp_##NAME : public UnaryOp { \
-		virtual const char *Name() { return #NAME; } \
-		virtual double op(double a) { return CODE; } \
-		virtual void loopz(int n, const Z *x, int astride, Z *y) { \
-                        LOOP(i,n) { Z a = *x; y[i] = CODE; x += astride; }  \
-		} \
-	}; \
-	UnaryOp_##NAME gUnaryOp_##NAME; \
-	UnaryOp* gUnaryOpPtr_##NAME = &gUnaryOp_##NAME; \
-	UNARY_OP_PRIM(NAME)
+#if SAMPLE_IS_DOUBLE
+	typedef Eigen::Map<Eigen::ArrayXd, 0, Eigen::InnerStride<>> ZArr;
+#else
+	typedef Eigen::Map<Eigen::ArrayXf, 0, Eigen::InnerStride<>> ZArr;
+#endif
 
-#define DEFINE_UNOP_FLOATVV2(NAME, CODE, VVCODE) \
+ZArr zarr(const Z *vec, int n, int stride) {
+	#if SAMPLE_IS_DOUBLE
+		return ZArr((double *)vec, n, Eigen::InnerStride<>(stride));
+	#else
+		return ZArr((float *)vec, n, Eigen::InnerStride<>(stride));
+	#endif
+}
+
+#define ZARR_BINOP(op, n, aa, astride, bb, bstride, out) \
+	do { \
+		const ZArr A = zarr(aa, n, astride); \
+		const ZArr B = zarr(bb, n, bstride); \
+		ZArr R = zarr(out, n, 1); \
+		R = op; \
+	} while (0)
+
+#define ZARR_UNOP(op, n, aa, astride, out) \
+	do { \
+		const ZArr A = zarr(aa, n, astride); \
+		ZArr R = zarr(out, n, 1); \
+		R = op; \
+	} while (0)
+
+#define DEFINE_UNOP_FLOATVV(NAME, CODE, OP) \
 	struct UnaryOp_##NAME : public UnaryOp { \
 		virtual const char *Name() { return #NAME; } \
 		virtual double op(double a) { return CODE; } \
 		virtual void loopz(int n, const Z *aa, int astride, Z *out) { \
-			LOOP(i,n) { Z a = *aa; out[i] = CODE; aa += astride; } \
+			if (astride == 1) { \
+				ZARR_UNOP(OP, n, aa, astride, out); \
+			} else { \
+				LOOP(i,n) { Z a = *aa; out[i] = CODE; aa += astride; } \
+			} \
 		} \
 	}; \
 	UnaryOp_##NAME gUnaryOp_##NAME; \
@@ -798,14 +819,23 @@ struct UnaryOp_ToZero : public UnaryOp {
 };
 UnaryOp_ToZero gUnaryOp_ToZero; 
 
-DEFINE_UNOP_FLOATVV2(neg, -a, vDSP_vnegD(const_cast<Z*>(aa), astride, out, 1, n))
+#ifdef SAPF_ACCELERATE
+	DEFINE_UNOP_FLOATVV2(neg, -a, vDSP_vnegD(const_cast<Z*>(aa), astride, out, 1, n))
+#else
+	DEFINE_UNOP_FLOATVV(neg, -a, A * -1)
+#endif
+
 DEFINE_UNOP_FLOAT(sgn, sc_sgn(a))
 
-DEFINE_UNOP_FLOATVV(abs, fabs(a), vvfabs)
+#ifdef SAPF_ACCELERATE
+	DEFINE_UNOP_FLOATVV(abs, fabs(a), vvfabs)
+#else
+	DEFINE_UNOP_FLOATVV(abs, fabs(a), A.abs())
+#endif
 
 DEFINE_UNOP_INT(tolower, tolower((int)a))
 DEFINE_UNOP_INT(toupper, toupper((int)a))
-// under mingw64, "toascii" is actually a #define for __toascii, so the macro doesn't do what's desired
+// under mingw64, "toascii" is actually a #define for __toascii, so the macro doesn't do what's desired 
 #ifdef _WIN32
 	#pragma push_macro("toascii")
 	#undef toascii
@@ -815,20 +845,36 @@ DEFINE_UNOP_INT(toupper, toupper((int)a))
 	DEFINE_UNOP_BOOL_INT(toascii, toascii((int)a))
 #endif
 
-DEFINE_UNOP_FLOATVV2(frac, a - floor(a), vvfloor(out, aa, &n); vDSP_vsubD(out, 1, aa, astride, out, 1, n))
-DEFINE_UNOP_FLOATVV(floor, floor(a), vvfloor)
-DEFINE_UNOP_FLOATVV(ceil, ceil(a), vvceil)
-DEFINE_UNOP_FLOATVV(rint, rint(a), vvnint)
+#ifdef SAPF_ACCELERATE
+	DEFINE_UNOP_FLOATVV2(frac, a - floor(a), vvfloor(out, aa, &n); vDSP_vsubD(out, 1, aa, astride, out, 1, n))
+	DEFINE_UNOP_FLOATVV(floor, floor(a), vvfloor)
+	DEFINE_UNOP_FLOATVV(ceil, ceil(a), vvceil)
+	DEFINE_UNOP_FLOATVV(rint, rint(a), vvnint)
+#else
+	DEFINE_UNOP_FLOATVV(frac, a - floor(a), A - A.floor())
+	DEFINE_UNOP_FLOATVV(floor, floor(a), A.floor())
+	DEFINE_UNOP_FLOATVV(ceil, ceil(a), A.ceil())
+	DEFINE_UNOP_FLOATVV(rint, rint(a), A.round())
+#endif
 
 DEFINE_UNOP_FLOAT(erf, erf(a))
 DEFINE_UNOP_FLOAT(erfc, erfc(a))
 
-DEFINE_UNOP_FLOATVV(recip, 1./a, vvrec)
-DEFINE_UNOP_FLOATVV(sqrt, sc_sqrt(a), vvsqrt)
-DEFINE_UNOP_FLOATVV(rsqrt, 1./sc_sqrt(a), vvrsqrt)
+#ifdef SAPF_ACCELERATE
+	DEFINE_UNOP_FLOATVV(recip, 1./a, vvrec)
+	DEFINE_UNOP_FLOATVV(sqrt, sc_sqrt(a), vvsqrt)
+	DEFINE_UNOP_FLOATVV(rsqrt, 1./sc_sqrt(a), vvrsqrt)
+	DEFINE_UNOP_FLOATVV2(ssq, copysign(a*a, a), vDSP_vssqD(aa, astride, out, 1, n))
+	DEFINE_UNOP_FLOATVV2(sq, a*a, vDSP_vsqD(aa, astride, out, 1, n))
+#else
+	DEFINE_UNOP_FLOATVV(recip, 1./a, 1. / A)
+	DEFINE_UNOP_FLOATVV(sqrt, sc_sqrt(a), A.sqrt())
+	DEFINE_UNOP_FLOATVV(rsqrt, 1./sc_sqrt(a), A.rsqrt())
+	DEFINE_UNOP_FLOATVV(ssq, copysign(a*a, a), A.sign() * A.square())
+	DEFINE_UNOP_FLOATVV(sq, a*a, A.square())
+#endif
 DEFINE_UNOP_FLOAT(cbrt, cbrt(a))
-DEFINE_UNOP_FLOATVV2(ssq, copysign(a*a, a), vDSP_vssqD(aa, astride, out, 1, n))
-DEFINE_UNOP_FLOATVV2(sq, a*a, vDSP_vsqD(aa, astride, out, 1, n))
+
 DEFINE_UNOP_FLOAT(cb, a*a*a)
 DEFINE_UNOP_FLOAT(pow4, sc_fourth(a))
 DEFINE_UNOP_FLOAT(pow5, sc_fifth(a))
@@ -837,32 +883,64 @@ DEFINE_UNOP_FLOAT(pow7, sc_seventh(a))
 DEFINE_UNOP_FLOAT(pow8, sc_eighth(a))
 DEFINE_UNOP_FLOAT(pow9, sc_ninth(a))
 
-DEFINE_UNOP_FLOATVV(exp, exp(a), vvexp)
-DEFINE_UNOP_FLOATVV(exp2, exp2(a), vvexp2)
+#ifdef SAPF_ACCELERATE
+	DEFINE_UNOP_FLOATVV(exp, exp(a), vvexp)
+	DEFINE_UNOP_FLOATVV(exp2, exp2(a), vvexp2)
+	DEFINE_UNOP_FLOATVV(expm1, expm1(a), vvexpm1)
+	DEFINE_UNOP_FLOATVV(log, sc_log(a), vvlog)
+	DEFINE_UNOP_FLOATVV(log2, sc_log2(a), vvlog2)
+	DEFINE_UNOP_FLOATVV(log10, sc_log10(a), vvlog10)
+	DEFINE_UNOP_FLOATVV(log1p, log1p(a), vvlog1p)
+#else
+	DEFINE_UNOP_FLOATVV(exp, exp(a), A.exp())
+	DEFINE_UNOP_FLOATVV(exp2, exp2(a), pow(2,A))
+	DEFINE_UNOP_FLOATVV(expm1, expm1(a), A.exp() - 1)
+	DEFINE_UNOP_FLOATVV(log, sc_log(a), A.log())
+	DEFINE_UNOP_FLOATVV(log2, sc_log2(a), A.log() / sc_log(2.0))
+	DEFINE_UNOP_FLOATVV(log10, sc_log10(a), A.log10())
+	DEFINE_UNOP_FLOATVV(log1p, log1p(a), A.log1p())
+#endif
 DEFINE_UNOP_FLOAT(exp10, pow(10., a))
-DEFINE_UNOP_FLOATVV(expm1, expm1(a), vvexpm1)
-DEFINE_UNOP_FLOATVV(log, sc_log(a), vvlog)
-DEFINE_UNOP_FLOATVV(log2, sc_log2(a), vvlog2)
-DEFINE_UNOP_FLOATVV(log10, sc_log10(a), vvlog10)
-DEFINE_UNOP_FLOATVV(log1p, log1p(a), vvlog1p)
-DEFINE_UNOP_FLOATVV(logb, logb(a), vvlogb)
+
+// TODO: Not vectorized in Eigen - possibly use XSIMD?
+#ifdef SAPF_ACCELERATE
+	DEFINE_UNOP_FLOATVV(logb, logb(a), vvlogb)
+#else
+	DEFINE_UNOP_FLOAT(logb, logb(a))
+#endif
 
 DEFINE_UNOP_FLOAT(sinc, sc_sinc(a))
-
-DEFINE_UNOP_FLOATVV(sin, sin(a), vvsin)
-DEFINE_UNOP_FLOATVV(cos, cos(a), vvcos)
-DEFINE_UNOP_FLOATVV2(sin1, sin(a * kTwoPi), Z b = kTwoPi; vDSP_vsmulD(const_cast<Z*>(aa), astride, &b, out, 1, n); vvsin(out, out, &n))
-DEFINE_UNOP_FLOATVV2(cos1, cos(a * kTwoPi), Z b = kTwoPi; vDSP_vsmulD(const_cast<Z*>(aa), astride, &b, out, 1, n); vvcos(out, out, &n))
-DEFINE_UNOP_FLOATVV(tan, tan(a), vvtan)
-DEFINE_UNOP_FLOATVV(asin, asin(a), vvasin)
-DEFINE_UNOP_FLOATVV(acos, acos(a), vvacos)
-DEFINE_UNOP_FLOATVV(atan, atan(a), vvatan)
-DEFINE_UNOP_FLOATVV(sinh, sinh(a), vvsinh)
-DEFINE_UNOP_FLOATVV(cosh, cosh(a), vvcosh)
-DEFINE_UNOP_FLOATVV(tanh, tanh(a), vvtanh)
-DEFINE_UNOP_FLOATVV(asinh, asinh(a), vvasinh)
-DEFINE_UNOP_FLOATVV(acosh, acosh(a), vvacosh)
-DEFINE_UNOP_FLOATVV(atanh, atanh(a), vvatanh)
+#ifdef SAPF_ACCELERATE
+	DEFINE_UNOP_FLOATVV(sin, sin(a), vvsin)
+	DEFINE_UNOP_FLOATVV(cos, cos(a), vvcos)
+	DEFINE_UNOP_FLOATVV2(sin1, sin(a * kTwoPi), Z b = kTwoPi; vDSP_vsmulD(const_cast<Z*>(aa), astride, &b, out, 1, n); vvsin(out, out, &n))
+	DEFINE_UNOP_FLOATVV2(cos1, cos(a * kTwoPi), Z b = kTwoPi; vDSP_vsmulD(const_cast<Z*>(aa), astride, &b, out, 1, n); vvcos(out, out, &n))
+	DEFINE_UNOP_FLOATVV(tan, tan(a), vvtan)
+	DEFINE_UNOP_FLOATVV(asin, asin(a), vvasin)
+	DEFINE_UNOP_FLOATVV(acos, acos(a), vvacos)
+	DEFINE_UNOP_FLOATVV(atan, atan(a), vvatan)
+	DEFINE_UNOP_FLOATVV(sinh, sinh(a), vvsinh)
+	DEFINE_UNOP_FLOATVV(cosh, cosh(a), vvcosh)
+	DEFINE_UNOP_FLOATVV(tanh, tanh(a), vvtanh)
+	DEFINE_UNOP_FLOATVV(asinh, asinh(a), vvasinh)
+	DEFINE_UNOP_FLOATVV(acosh, acosh(a), vvacosh)
+	DEFINE_UNOP_FLOATVV(atanh, atanh(a), vvatanh)
+#else
+	DEFINE_UNOP_FLOATVV(sin, sin(a), A.sin())
+	DEFINE_UNOP_FLOATVV(cos, cos(a), A.cos())
+	DEFINE_UNOP_FLOATVV(sin1, sin(a * kTwoPi), (kTwoPi * A).sin())
+	DEFINE_UNOP_FLOATVV(cos1, cos(a * kTwoPi), (kTwoPi * A).cos())
+	DEFINE_UNOP_FLOATVV(tan, tan(a), A.tan())
+	DEFINE_UNOP_FLOATVV(asin, asin(a), A.asin())
+	DEFINE_UNOP_FLOATVV(acos, acos(a), A.acos())
+	DEFINE_UNOP_FLOATVV(atan, atan(a), A.atan())
+	DEFINE_UNOP_FLOATVV(sinh, sinh(a), A.sinh())
+	DEFINE_UNOP_FLOATVV(cosh, cosh(a), A.cosh())
+	DEFINE_UNOP_FLOATVV(tanh, tanh(a), A.tanh())
+	DEFINE_UNOP_FLOATVV(asinh, asinh(a), A.asinh())
+	DEFINE_UNOP_FLOATVV(acosh, acosh(a), A.acosh())
+	DEFINE_UNOP_FLOATVV(atanh, atanh(a), A.atanh())
+#endif
 
 #ifdef _WIN32
 	DEFINE_UNOP_FLOAT(J0, _j0(a))
@@ -886,19 +964,36 @@ static void sc_clipv(int n, const Z* in, Z* out, Z a, Z b)
 	}
 }
 
-DEFINE_UNOP_FLOATVV2(inc, a+1, Z b = 1.; vDSP_vsaddD(const_cast<Z*>(aa), astride, &b, out, 1, n))
-DEFINE_UNOP_FLOATVV2(dec, a-1, Z b = -1.; vDSP_vsaddD(const_cast<Z*>(aa), astride, &b, out, 1, n))
-DEFINE_UNOP_FLOATVV2(half, a*.5, Z b = .5; vDSP_vsmulD(aa, astride, &b, out, 1, n))
-DEFINE_UNOP_FLOATVV2(twice, a*2., Z b = 2.; vDSP_vsmulD(const_cast<Z*>(aa), astride, &b, out, 1, n))
+#ifdef SAPF_ACCELERATE
+	DEFINE_UNOP_FLOATVV2(inc, a+1, Z b = 1.; vDSP_vsaddD(const_cast<Z*>(aa), astride, &b, out, 1, n))
+	DEFINE_UNOP_FLOATVV2(dec, a-1, Z b = -1.; vDSP_vsaddD(const_cast<Z*>(aa), astride, &b, out, 1, n))
+	DEFINE_UNOP_FLOATVV2(half, a*.5, Z b = .5; vDSP_vsmulD(aa, astride, &b, out, 1, n))
+	DEFINE_UNOP_FLOATVV2(twice, a*2., Z b = 2.; vDSP_vsmulD(const_cast<Z*>(aa), astride, &b, out, 1, n))
+#else
+	DEFINE_UNOP_FLOATVV(inc, a+1, A + 1)
+	DEFINE_UNOP_FLOATVV(dec, a-1, A - 1)
+	DEFINE_UNOP_FLOATVV(half, a*.5, A * .5)
+	DEFINE_UNOP_FLOATVV(twice, a*2., A * 2.)
+#endif
 
-
-DEFINE_UNOP_FLOATVV2(biuni, a*.5+.5, Z b = .5; vDSP_vsmulD(const_cast<Z*>(aa), astride, &b, out, 1, n); vDSP_vsaddD(out, 1, &b, out, 1, n))
-DEFINE_UNOP_FLOATVV2(unibi, a*2.-1., Z b = 2.; Z c = -1.; vDSP_vsmulD(aa, astride, &b, out, 1, n); vDSP_vsaddD(out, 1, &c, out, 1, n))
-DEFINE_UNOP_FLOATVV2(biunic, std::clamp(a,-1.,1.)*.5+.5, Z b = .5; sc_clipv(n, aa, out, -1., 1.); vDSP_vsmulD(out, astride, &b, out, 1, n); vDSP_vsaddD(out, 1, &b, out, 1, n))
-DEFINE_UNOP_FLOATVV2(unibic, std::clamp(a,0.,1.)*2.-1., Z b = 2.; Z c = -1.; sc_clipv(n, aa, out, 0., 1.); vDSP_vsmulD(out, astride, &b, out, 1, n); vDSP_vsaddD(out, 1, &c, out, 1, n))
+#ifdef SAPF_ACCELERATE
+	DEFINE_UNOP_FLOATVV2(biuni, a*.5+.5, Z b = .5; vDSP_vsmulD(const_cast<Z*>(aa), astride, &b, out, 1, n); vDSP_vsaddD(out, 1, &b, out, 1, n))
+	DEFINE_UNOP_FLOATVV2(unibi, a*2.-1., Z b = 2.; Z c = -1.; vDSP_vsmulD(aa, astride, &b, out, 1, n); vDSP_vsaddD(out, 1, &c, out, 1, n))
+	DEFINE_UNOP_FLOATVV2(biunic, std::clamp(a,-1.,1.)*.5+.5, Z b = .5; sc_clipv(n, aa, out, -1., 1.); vDSP_vsmulD(out, astride, &b, out, 1, n); vDSP_vsaddD(out, 1, &b, out, 1, n))
+	DEFINE_UNOP_FLOATVV2(unibic, std::clamp(a,0.,1.)*2.-1., Z b = 2.; Z c = -1.; sc_clipv(n, aa, out, 0., 1.); vDSP_vsmulD(out, astride, &b, out, 1, n); vDSP_vsaddD(out, 1, &c, out, 1, n))
+#else
+	DEFINE_UNOP_FLOATVV(biuni, a*.5+.5, A * .5 + .5)
+	DEFINE_UNOP_FLOATVV(unibi, a*2.-1., A * 2. - 1.)
+	DEFINE_UNOP_FLOATVV(biunic, std::clamp(a,-1.,1.)*.5+.5, A.min(1.).max(-1.) * .5 + .5)
+	DEFINE_UNOP_FLOATVV(unibic, std::clamp(a,0.,1.)*2.-1., A.min(1.).max(0.) * 2. - 1.)
+#endif
 DEFINE_UNOP_FLOAT(cmpl, 1.-a)
 
-DEFINE_UNOP_FLOATVV2(ampdb,     sc_ampdb(a), Z b = 1.; vDSP_vdbconD(const_cast<Z*>(aa), astride, &b, out, 1, n, 1))
+#ifdef SAPF_ACCELERATE
+	DEFINE_UNOP_FLOATVV2(ampdb, sc_ampdb(a), Z b = 1.; vDSP_vdbconD(const_cast<Z*>(aa), astride, &b, out, 1, n, 1))
+#else
+	DEFINE_UNOP_FLOATVV(ampdb, sc_ampdb(a), A.log10() * 20.)	
+#endif
 DEFINE_UNOP_FLOAT(dbamp,     sc_dbamp(a))
 
 DEFINE_UNOP_FLOAT(hzo,   sc_hzoct(a))
@@ -916,11 +1011,19 @@ DEFINE_UNOP_FLOAT(ratiocents, sc_ratiocents(a))
 DEFINE_UNOP_FLOAT(semiratio, sc_semiratio(a))
 DEFINE_UNOP_FLOAT(ratiosemi, sc_ratiosemi(a))
 
-DEFINE_UNOP_FLOATVV2(degrad, a*kDegToRad, Z b = kDegToRad; vDSP_vsmulD(aa, astride, &b, out, 1, n))
-DEFINE_UNOP_FLOATVV2(raddeg, a*kRadToDeg, Z b = kRadToDeg; vDSP_vsmulD(aa, astride, &b, out, 1, n))
-DEFINE_UNOP_FLOATVV2(minsec, a*kMinToSecs, Z b = kMinToSecs; vDSP_vsmulD(aa, astride, &b, out, 1, n))
-DEFINE_UNOP_FLOATVV2(secmin, a*kSecsToMin, Z b = kSecsToMin; vDSP_vsmulD(aa, astride, &b, out, 1, n))
-DEFINE_UNOP_FLOATVV2(bpmsec, kMinToSecs / a, Z b = kMinToSecs; vDSP_svdivD(&b, const_cast<double*>(aa), astride, out, 1, n))
+#ifdef SAPF_ACCELERATE
+	DEFINE_UNOP_FLOATVV2(degrad, a*kDegToRad, Z b = kDegToRad; vDSP_vsmulD(aa, astride, &b, out, 1, n))
+	DEFINE_UNOP_FLOATVV2(raddeg, a*kRadToDeg, Z b = kRadToDeg; vDSP_vsmulD(aa, astride, &b, out, 1, n))
+	DEFINE_UNOP_FLOATVV2(minsec, a*kMinToSecs, Z b = kMinToSecs; vDSP_vsmulD(aa, astride, &b, out, 1, n))
+	DEFINE_UNOP_FLOATVV2(secmin, a*kSecsToMin, Z b = kSecsToMin; vDSP_vsmulD(aa, astride, &b, out, 1, n))
+	DEFINE_UNOP_FLOATVV2(bpmsec, kMinToSecs / a, Z b = kMinToSecs; vDSP_svdivD(&b, const_cast<double*>(aa), astride, out, 1, n))
+#else
+	DEFINE_UNOP_FLOATVV(degrad, a*kDegToRad, A * kDegToRad)
+	DEFINE_UNOP_FLOATVV(raddeg, a*kRadToDeg, A * kRadToDeg)
+	DEFINE_UNOP_FLOATVV(minsec, a*kMinToSecs, A * kMinToSecs)
+	DEFINE_UNOP_FLOATVV(secmin, a*kSecsToMin, A * kSecsToMin)
+	DEFINE_UNOP_FLOATVV(bpmsec, kMinToSecs / a, kMinToSecs / A)	
+#endif
 
 DEFINE_UNOP_FLOAT(distort,  sc_distort(a))
 DEFINE_UNOP_FLOAT(softclip, sc_softclip(a))
@@ -949,30 +1052,6 @@ DEFINE_BINOP_FLOAT_STRING(cmp,  sc_cmp(a, b), sc_sgn(strcmp(a, b)))
 DEFINE_BINOP_FLOATVV1(copysign, copysign(a, b), vvcopysign(out, const_cast<Z*>(aa), bb, &n)) // bug in vForce.h requires const_cast
 DEFINE_BINOP_FLOATVV1(nextafter, nextafter(a, b), vvnextafter(out, const_cast<Z*>(aa), bb, &n)) // bug in vForce.h requires const_cast
 
-#ifndef SAPF_ACCELERATE
-
-	#if SAMPLE_IS_DOUBLE
-		typedef Eigen::Map<Eigen::ArrayXd, 0, Eigen::InnerStride<>> ZArr;
-	#else
-		typedef Eigen::Map<Eigen::ArrayXf, 0, Eigen::InnerStride<>> ZArr;
-	#endif
-
-	ZArr zarr(const Z *vec, int n, int stride) {
-		#if SAMPLE_IS_DOUBLE
-			return ZArr((double *)vec, n, Eigen::InnerStride<>(stride));
-		#else
-			return ZArr((float *)vec, n, Eigen::InnerStride<>(stride));
-		#endif
-	}
-
-	#define ZARR_OP(op, n, aa, astride, bb, bstride, out) \
-		do { \
-			const ZArr A = zarr(aa, n, astride); \
-			const ZArr B = zarr(bb, n, bstride); \
-			ZArr R = zarr(out, n, 1); \
-			R = op; \
-		} while (0)
-#endif
 
 // identity optimizations of basic operators.
 
@@ -988,7 +1067,7 @@ DEFINE_BINOP_FLOATVV1(nextafter, nextafter(a, b), vvnextafter(out, const_cast<Z*
 #ifdef SAPF_ACCELERATE
 					vDSP_vsaddD(const_cast<Z*>(bb), bstride, const_cast<Z*>(aa), out, 1, n);
 #else
-					ZARR_OP(A + B, n, aa, astride, bb, bstride, out);
+					ZARR_BINOP(A + B, n, aa, astride, bb, bstride, out);
 #endif // SAPF_ACCELERATE
 				}
 			} else if (bstride == 0 ) {
@@ -998,14 +1077,14 @@ DEFINE_BINOP_FLOATVV1(nextafter, nextafter(a, b), vvnextafter(out, const_cast<Z*
 #ifdef SAPF_ACCELERATE
 					vDSP_vsaddD(const_cast<Z*>(aa), astride, const_cast<Z*>(bb), out, 1, n);
 #else
-                    ZARR_OP(A + B, n, aa, astride, bb, bstride, out);
+                    ZARR_BINOP(A + B, n, aa, astride, bb, bstride, out);
 #endif // SAPF_ACCELERATE
 				}
 			} else {
 #ifdef SAPF_ACCELERATE
 				vDSP_vaddD(aa, astride, bb, bstride, out, 1, n);
 #else
-					ZARR_OP(A + B, n, aa, astride, bb, bstride, out);
+					ZARR_BINOP(A + B, n, aa, astride, bb, bstride, out);
 #endif // SAPF_ACCELERATE
 			}
         }
@@ -1054,7 +1133,7 @@ DEFINE_BINOP_FLOATVV1(nextafter, nextafter(a, b), vvnextafter(out, const_cast<Z*
 #ifdef SAPF_ACCELERATE
 					vDSP_vsaddD(const_cast<Z*>(bb), bstride, const_cast<Z*>(aa), out, 1, n);
 #else
-					ZARR_OP(A + B, n, aa, astride, bb, bstride, out);
+					ZARR_BINOP(A + B, n, aa, astride, bb, bstride, out);
 #endif // SAPF_ACCELERATE
 				}
 			} else if (bstride == 0 ) {
@@ -1065,14 +1144,14 @@ DEFINE_BINOP_FLOATVV1(nextafter, nextafter(a, b), vvnextafter(out, const_cast<Z*
 #ifdef SAPF_ACCELERATE
 					vDSP_vsaddD(const_cast<Z*>(aa), astride, const_cast<Z*>(bb), out, 1, n);
 #else
-					ZARR_OP(A + B, n, aa, astride, bb, bstride, out);
+					ZARR_BINOP(A + B, n, aa, astride, bb, bstride, out);
 #endif // SAPF_ACCELERATE
 				}
 			} else {
 #ifdef SAPF_ACCELERATE
 				vDSP_vaddD(aa, astride, bb, bstride, out, 1, n);
 #else
-				ZARR_OP(A + B, n, aa, astride, bb, bstride, out);
+				ZARR_BINOP(A + B, n, aa, astride, bb, bstride, out);
 #endif // SAPF_ACCELERATE
 			}
 		}
@@ -1117,13 +1196,13 @@ DEFINE_BINOP_FLOATVV1(nextafter, nextafter(a, b), vvnextafter(out, const_cast<Z*
 #ifdef SAPF_ACCELERATE
 				vDSP_vnegD(const_cast<Z*>(bb), bstride, out, 1, n);
 #else
-				ZARR_OP(A - B, n, aa, astride, bb, bstride, out);
+				ZARR_BINOP(A - B, n, aa, astride, bb, bstride, out);
 #endif // SAPF_ACCELERATE
 				if (*aa != 0.) {
 #ifdef SAPF_ACCELERATE
 					vDSP_vsaddD(const_cast<Z*>(out), 1, const_cast<Z*>(aa), out, 1, n);
 #else
-					ZARR_OP(A - B, n, aa, astride, bb, bstride, out);
+					ZARR_BINOP(A - B, n, aa, astride, bb, bstride, out);
 #endif // SAPF_ACCELERATE
 				}
 			} else if (bstride == 0 ) {
@@ -1133,14 +1212,14 @@ DEFINE_BINOP_FLOATVV1(nextafter, nextafter(a, b), vvnextafter(out, const_cast<Z*
 #ifdef SAPF_ACCELERATE
 					vDSP_vsaddD(const_cast<Z*>(out), 1, &b, out, 1, n);
 #else
-					ZARR_OP(A - B, n, aa, astride, bb, bstride, out);
+					ZARR_BINOP(A - B, n, aa, astride, bb, bstride, out);
 #endif // SAPF_ACCELERATE
 				}
 			} else {
 #ifdef SAPF_ACCELERATE
 				vDSP_vsubD(aa, astride, bb, bstride, out, 1, n);
 #else
-				ZARR_OP(A - B, n, aa, astride, bb, bstride, out);
+				ZARR_BINOP(A - B, n, aa, astride, bb, bstride, out);
 #endif // SAPF_ACCELERATE
 			}
 		}
@@ -1191,7 +1270,7 @@ DEFINE_BINOP_FLOATVV1(nextafter, nextafter(a, b), vvnextafter(out, const_cast<Z*
 #ifdef SAPF_ACCELERATE
 					vDSP_vsmulD(bb, bstride, aa, out, 1, n);
 #else
-					ZARR_OP(A * B, n, aa, astride, bb, bstride, out);
+					ZARR_BINOP(A * B, n, aa, astride, bb, bstride, out);
 #endif // SAPF_ACCELERATE
 				}
 			} else if (bstride == 0) {
@@ -1203,14 +1282,14 @@ DEFINE_BINOP_FLOATVV1(nextafter, nextafter(a, b), vvnextafter(out, const_cast<Z*
 #ifdef SAPF_ACCELERATE
 					vDSP_vsmulD(aa, astride, bb, out, 1, n);
 #else
-                    ZARR_OP(A * B, n, aa, astride, bb, bstride, out);
+                    ZARR_BINOP(A * B, n, aa, astride, bb, bstride, out);
 #endif // SAPF_ACCELERATE
 				}
 			} else {
 #ifdef SAPF_ACCELERATE
 				vDSP_vmulD(aa, astride, bb, bstride, out, 1, n);
 #else
-				ZARR_OP(A * B, n, aa, astride, bb, bstride, out);
+				ZARR_BINOP(A * B, n, aa, astride, bb, bstride, out);
 #endif // SAPF_ACCELERATE
 			}
 		}
@@ -1278,14 +1357,14 @@ DEFINE_BINOP_FLOATVV1(nextafter, nextafter(a, b), vvnextafter(out, const_cast<Z*
 #ifdef SAPF_ACCELERATE
 					vDSP_vsmulD(const_cast<Z*>(aa), astride, &rb, out, 1, n);
 #else
-                    ZARR_OP(A / B, n, aa, astride, bb, bstride, out);
+                    ZARR_BINOP(A / B, n, aa, astride, bb, bstride, out);
 #endif // SAPF_ACCELERATE
 				}
 			} else {
 #ifdef SAPF_ACCELERATE
 				vDSP_vdivD(const_cast<Z*>(bb), bstride, const_cast<Z*>(aa), astride, out, 1, n);
 #else
-                 ZARR_OP(A / B, n, aa, astride, bb, bstride, out);
+                 ZARR_BINOP(A / B, n, aa, astride, bb, bstride, out);
 #endif // SAPF_ACCELERATE
 			}
 		}
@@ -1425,7 +1504,7 @@ void AddMathOps()
 	#else
 		DEF(isascii, "return whether a value is ASCII")
 	#endif
-
+	
 
 	DEF(tolower, "convert an ASCII character value to lower case.")
 	DEF(toupper, "convert an ASCII character value to upper case.")

--- a/subprojects/doctest.wrap
+++ b/subprojects/doctest.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = doctest-2.4.11
+source_url = https://github.com/doctest/doctest/archive/refs/tags/v2.4.11.tar.gz
+source_filename = doctest-2.4.11.tar.gz
+source_hash = 632ed2c05a7f53fa961381497bf8069093f0d6628c5f26286161fbd32a560186
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/doctest_2.4.11-1/doctest-2.4.11.tar.gz
+wrapdb_version = 2.4.11-1
+
+[provide]
+dependency_names = doctest

--- a/subprojects/eigen.wrap
+++ b/subprojects/eigen.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = eigen-3.4.0
+source_url = https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.bz2
+source_filename = eigen-3.4.0.tar.bz2
+source_hash = b4c198460eba6f28d34894e3a5710998818515104d6e74e5cc331ce31e46e626
+patch_filename = eigen_3.4.0-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/eigen_3.4.0-2/get_patch
+patch_hash = cb764fd9fec02d94aaa2ec673d473793c0d05da4f4154c142f76ef923ea68178
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/eigen_3.4.0-2/eigen-3.4.0.tar.bz2
+wrapdb_version = 3.4.0-2
+
+[provide]
+eigen3 = eigen_dep

--- a/test/test_MathOps.cpp
+++ b/test/test_MathOps.cpp
@@ -1,0 +1,49 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "Object.hpp"
+#include "doctest.h"
+#include <array>
+
+
+#define CHECK_ARR(expected, actual, n) \
+	do { \
+		LOOP(i,n) { CHECK(out[i] == doctest::Approx(expected[i]).epsilon(1e-9)); } \
+	} while (0)
+
+
+// so we can access ops directly
+extern BinaryOp* gBinaryOpPtr_plus;
+extern BinaryOp* gBinaryOpPtr_minus;
+extern BinaryOp* gBinaryOpPtr_mul;
+extern BinaryOp* gBinaryOpPtr_div;
+
+using std::array;
+
+void check_binop_loopz(BinaryOp& op, const std::array<Z, 3> a, int astride, const std::array<Z, 3> b, int bstride) {
+	double out[3];
+	double expected[3] = {op.op(a[0], b[0]), op.op(a[1], b[1]), op.op(a[2], b[2])};
+	op.loopz(3, a.data(), 1, b.data(), 1, out);
+	CHECK_ARR(expected, out, 3);
+}
+
+void check_binop_loopz(BinaryOp& op, int astride, int bstride) {
+	check_binop_loopz(op, {1, 2, 3}, astride, {4, 5, 6}, bstride);
+}
+
+#define CHECK_IDENTITY_BINOP(op) \
+	do { \
+		SUBCASE(#op) { \
+			SUBCASE("stride 1") { check_binop_loopz(*gBinaryOpPtr_##op, 1, 1); } \
+			SUBCASE("stride 0") { check_binop_loopz(*gBinaryOpPtr_##op, 0, 0); } \
+			SUBCASE("astride 1") { check_binop_loopz(*gBinaryOpPtr_##op, 1, 0); } \
+			SUBCASE("bstride 1") { check_binop_loopz(*gBinaryOpPtr_##op, 0, 1); } \
+			SUBCASE("a 0") { check_binop_loopz(*gBinaryOpPtr_##op, {0}, 0, {4, 5, 6}, 1); } \
+			SUBCASE("b 0") { check_binop_loopz(*gBinaryOpPtr_##op, {1, 2, 3}, 1, {4, 5, 6}, 0); } \
+		} \
+	} while (0)
+
+TEST_CASE("identity binops") {
+	CHECK_IDENTITY_BINOP(plus);
+	CHECK_IDENTITY_BINOP(minus);
+	CHECK_IDENTITY_BINOP(div);
+	CHECK_IDENTITY_BINOP(mul);
+}

--- a/test/test_MathOps.cpp
+++ b/test/test_MathOps.cpp
@@ -47,3 +47,124 @@ TEST_CASE("identity binops") {
 	CHECK_IDENTITY_BINOP(div);
 	CHECK_IDENTITY_BINOP(mul);
 }
+
+void check_unop_loopz(UnaryOp& op, const std::array<Z, 3> in) {
+	double out[3];
+	double expected[3] = {op.op(in[0]), op.op(in[1]), op.op(in[2])};
+	op.loopz(3, in.data(), 1, out);
+	CHECK_ARR(expected, out, 3);
+}
+
+void check_unop_loopz(UnaryOp& op) {
+	check_unop_loopz(op, {1, 2, 3});
+}
+
+extern UnaryOp* gUnaryOpPtr_neg;
+extern UnaryOp* gUnaryOpPtr_abs;
+extern UnaryOp* gUnaryOpPtr_frac;
+extern UnaryOp* gUnaryOpPtr_floor;
+extern UnaryOp* gUnaryOpPtr_ceil;
+extern UnaryOp* gUnaryOpPtr_rint;
+extern UnaryOp* gUnaryOpPtr_recip;
+extern UnaryOp* gUnaryOpPtr_sqrt;
+extern UnaryOp* gUnaryOpPtr_rsqrt;
+extern UnaryOp* gUnaryOpPtr_ssq;
+extern UnaryOp* gUnaryOpPtr_sq;
+extern UnaryOp* gUnaryOpPtr_exp;
+extern UnaryOp* gUnaryOpPtr_exp2;
+extern UnaryOp* gUnaryOpPtr_expm1;
+extern UnaryOp* gUnaryOpPtr_log;
+extern UnaryOp* gUnaryOpPtr_log2;
+extern UnaryOp* gUnaryOpPtr_log10;
+extern UnaryOp* gUnaryOpPtr_log1p;
+extern UnaryOp* gUnaryOpPtr_sin;
+extern UnaryOp* gUnaryOpPtr_cos;
+extern UnaryOp* gUnaryOpPtr_sin1;
+extern UnaryOp* gUnaryOpPtr_cos1;
+extern UnaryOp* gUnaryOpPtr_tan;
+extern UnaryOp* gUnaryOpPtr_atan;
+extern UnaryOp* gUnaryOpPtr_sinh;
+extern UnaryOp* gUnaryOpPtr_cosh;
+extern UnaryOp* gUnaryOpPtr_tanh;
+extern UnaryOp* gUnaryOpPtr_asinh;
+extern UnaryOp* gUnaryOpPtr_acosh;
+extern UnaryOp* gUnaryOpPtr_inc;
+extern UnaryOp* gUnaryOpPtr_dec;
+extern UnaryOp* gUnaryOpPtr_half;
+extern UnaryOp* gUnaryOpPtr_twice;
+extern UnaryOp* gUnaryOpPtr_biuni;
+extern UnaryOp* gUnaryOpPtr_unibi;
+extern UnaryOp* gUnaryOpPtr_biunic;
+extern UnaryOp* gUnaryOpPtr_unibic;
+extern UnaryOp* gUnaryOpPtr_ampdb;
+extern UnaryOp* gUnaryOpPtr_degrad;
+extern UnaryOp* gUnaryOpPtr_raddeg;
+extern UnaryOp* gUnaryOpPtr_minsec;
+extern UnaryOp* gUnaryOpPtr_secmin;
+extern UnaryOp* gUnaryOpPtr_bpmsec;
+extern UnaryOp* gUnaryOpPtr_asin;
+extern UnaryOp* gUnaryOpPtr_acos;
+extern UnaryOp* gUnaryOpPtr_atanh;
+
+#define CHECK_UNOP(op) \
+	do { \
+		SUBCASE(#op) { \
+			check_unop_loopz(*gUnaryOpPtr_##op); \
+		} \
+	} while (0)
+
+#define CHECK_UNOP_NORMALIZED(op) \
+	do { \
+		SUBCASE(#op) { \
+			check_unop_loopz(*gUnaryOpPtr_##op, {-.1, 0, .1}); \
+		} \
+	} while (0)
+
+TEST_CASE("unary ops") {
+	CHECK_UNOP(neg);
+	CHECK_UNOP(abs);
+	CHECK_UNOP(frac);
+	CHECK_UNOP(floor);
+	CHECK_UNOP(ceil);
+	CHECK_UNOP(rint);
+	CHECK_UNOP(recip);
+	CHECK_UNOP(sqrt);
+	CHECK_UNOP(rsqrt);
+	CHECK_UNOP(ssq);
+	CHECK_UNOP(sq);
+	CHECK_UNOP(exp);
+	CHECK_UNOP(exp2);
+	CHECK_UNOP(expm1);
+	CHECK_UNOP(log);
+	CHECK_UNOP(log2);
+	CHECK_UNOP(log10);
+	CHECK_UNOP(log1p);
+	CHECK_UNOP(sin);
+	CHECK_UNOP(cos);
+	CHECK_UNOP(sin1);
+	CHECK_UNOP(cos1);
+	CHECK_UNOP(tan);
+	CHECK_UNOP(atan);
+	CHECK_UNOP(sinh);
+	CHECK_UNOP(cosh);
+	CHECK_UNOP(tanh);
+	CHECK_UNOP(asinh);
+	CHECK_UNOP(acosh);
+	CHECK_UNOP(inc);
+	CHECK_UNOP(dec);
+	CHECK_UNOP(half);
+	CHECK_UNOP(twice);
+	CHECK_UNOP(biuni);
+	CHECK_UNOP(unibi);
+	CHECK_UNOP(biunic);
+	CHECK_UNOP(unibic);
+	CHECK_UNOP(ampdb);
+	CHECK_UNOP(degrad);
+	CHECK_UNOP(raddeg);
+	CHECK_UNOP(minsec);
+	CHECK_UNOP(secmin);
+	CHECK_UNOP(bpmsec);
+	CHECK_UNOP_NORMALIZED(asin);
+	CHECK_UNOP_NORMALIZED(acos);
+	CHECK_UNOP_NORMALIZED(atanh);
+}


### PR DESCRIPTION
Depends on https://github.com/ahihi/sapf/pull/16
Relates to https://github.com/ahihi/sapf/issues/8

THIS WILL NOT BE MERGED AS-IS! I am just creating this to show what I have "ready to go" (but of course will rework it if the dependent PR needs significant changes). Once / if the dependent PR is merged, I'll create a proper PR for upstream.

Ports all vectorized unary operators (unops) to work on Eigen (on non-OSX), and adds tests for all of them (the ported ones only). Also discovered we get more useful test reporting if we use the `--verbose` option of `meson test` so I updated the README on that point. 
With how simple the Eigen library is to use, we could even vectorize more of these operations (that aren't vectorized in the OSX version) later if we want!

Using the templating feature of doctest, I was able to avoid a lot of duplication with the test cases. They validate that the vectorized version gets the same result as the non-vectorized operation.
